### PR TITLE
allow access to openai api compatiable llms at localhost or other add…

### DIFF
--- a/integrations/openaiwrapper.py
+++ b/integrations/openaiwrapper.py
@@ -32,7 +32,7 @@ class OpenAIAPIWrapper:
         self.api_key = api_key
         openai.api_key = api_key
         if API_BASE is not None:
-           logging.error("Accessing OPENAI at %s" % API_BASE)
+           logging.debug("Accessing OPENAI at %s" % API_BASE)
            openai.api_base = API_BASE
         self.timeout = timeout
 

--- a/integrations/openaiwrapper.py
+++ b/integrations/openaiwrapper.py
@@ -51,14 +51,14 @@ class OpenAIAPIWrapper:
             try:
                 return openai.Embedding.create(input=text, engine=ENGINE)
             except openai.error.OpenAIError as e:
-                logging.exception(f"OpenAI API error: {e}")
+                logging.error(f"OpenAI API error: {e}")
                 retries += 1
                 if retries >= MAX_RETRIES:
                     raise
                 time.sleep(RETRY_SLEEP_DURATION)
 
                 if f"{e}".startswith("Rate limit"):
-                   logging.debug("Rate limit reached...  sleeping for 20 seconds")
+                   print("Rate limit reached...  sleeping for 20 seconds")
                    start_time+=20
                    time.sleep(20)
         raise TimeoutError("API call timed out")
@@ -86,14 +86,14 @@ class OpenAIAPIWrapper:
                    return res['choices'][0].message['content'].strip()
                 return res.choices[0].message['content'].strip()
             except openai.error.OpenAIError as e:
-                logging.exception(f"OpenAI API error: {e}")
+                logging.error(f"OpenAI API error: {e}")
                 retries += 1
                 if retries >= MAX_RETRIES:
                     raise
                 time.sleep(RETRY_SLEEP_DURATION)
 
                 if f"{e}".startswith("Rate limit"):
-                   logging.debug("Rate limit reached...  sleeping for 20 seconds")
+                   print("Rate limit reached...  sleeping for 20 seconds")
                    start_time+=20
                    time.sleep(20)
         raise TimeoutError("API call timed out")


### PR DESCRIPTION
modify openaiwrapper so that if a user wants to access another llm that is openai api compatible they can by adding an environment variable OPENAI_API_BASE which modifies the openai.api_base variable in the openai library.

For example if someone wants to use models at localai, they can execute the instructions at https://localai.io/basics/getting_started/  to download a docker image, etc and then use this branch to access the web server running on docker.