### PR TITLE
update agents so that duplicate embedded purpose lookups are eliminated

### DIFF
--- a/agents/agent_similarity.py
+++ b/agents/agent_similarity.py
@@ -47,8 +47,6 @@ class AgentSimilarity:
             for agent in self.agents:
                 if agent.embedding_purpose is None:
                    agent.embedding_purpose = self.get_embedding(agent.purpose)
-                else:
-                   print("\nUsing embedding_purpose variable instead of api lookup")
 
                 embeddings.append(agent.embedding_purpose)
 
@@ -75,8 +73,6 @@ class AgentSimilarity:
             for agent in self.agents:
                 if agent.embedding_purpose is None:
                    agent.embedding_purpose = self.get_embedding(agent.purpose)
-                else:
-                   print("\nUsing embedding_purpose variable instead of api lookup")
 
                 similarity = cosine_similarity([agent.embedding_purpose], [purpose_embedding])[0][0]
 

--- a/agents/agent_similarity.py
+++ b/agents/agent_similarity.py
@@ -6,6 +6,7 @@ from integrations.openaiwrapper import OpenAIAPIWrapper
 class Agent:
     def __init__(self, purpose: str):
         self.purpose = purpose
+        self.embedding_purpose=None
 
 class AgentSimilarity:
     def __init__(self, openai_wrapper: OpenAIAPIWrapper, agents: List[Agent]):
@@ -42,7 +43,15 @@ class AgentSimilarity:
         :return: 98th percentile of similarity threshold.
         """
         try:
-            embeddings = [self.get_embedding(agent.purpose) for agent in self.agents]
+            embeddings=[]
+            for agent in self.agents:
+                if agent.embedding_purpose is None:
+                   agent.embedding_purpose = self.get_embedding(agent.purpose)
+                else:
+                   print("\nUsing embedding_purpose variable instead of api lookup")
+
+                embeddings.append(agent.embedding_purpose)
+
             if len(embeddings) < 250:
                 return 0.9
 
@@ -64,8 +73,12 @@ class AgentSimilarity:
 
         try:
             for agent in self.agents:
-                agent_embedding = self.get_embedding(agent.purpose)
-                similarity = cosine_similarity([agent_embedding], [purpose_embedding])[0][0]
+                if agent.embedding_purpose is None:
+                   agent.embedding_purpose = self.get_embedding(agent.purpose)
+                else:
+                   print("\nUsing embedding_purpose variable instead of api lookup")
+
+                similarity = cosine_similarity([agent.embedding_purpose], [purpose_embedding])[0][0]
 
                 if similarity > highest_similarity:
                     highest_similarity = similarity

--- a/agents/microagent.py
+++ b/agents/microagent.py
@@ -19,6 +19,7 @@ class MicroAgent:
     def __init__(self, initial_prompt, purpose, depth, agent_creator, openai_wrapper, max_depth=3, bootstrap_agent=False, is_prime=False):
         self.dynamic_prompt = initial_prompt
         self.purpose = purpose
+        self.embedding_purpose = None
         self.depth = depth
         self.max_depth = max_depth
         self.usage_count = 0


### PR DESCRIPTION
I noticed that sometimes we lookup the embeddings for the same agent (ie, purpose string).  Added embedding_purpose variable to hold the embedding so we don't have to make the api call more than once.